### PR TITLE
v2.0.0

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -9,7 +9,7 @@
 	"dependencies": {
 		"react": "16.0.0-alpha.12",
 		"react-native": "0.47.1",
-		"react-native-offline-api": "^1.1.0"
+		"react-native-offline-api": "2.0.0"
 	},
 	"devDependencies": {
 		"babel-jest": "20.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-offline-api",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "Offline first API wrapper for react-native",
   "main": "./dist/index.js",
   "types": "./src/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -454,6 +454,9 @@ export default class OfflineFirstAPI {
         if (options && options.pathParameters) {
             const { pathParameters } = options;
             for (let i in pathParameters) {
+                if (typeof pathParameters[i] === 'undefined') {
+                    continue;
+                }
                 path = path.replace(`:${i}`, pathParameters[i]);
             }
         }
@@ -461,7 +464,10 @@ export default class OfflineFirstAPI {
             const { queryParameters } = options;
             let insertedQueryParameters = 0;
             for (let i in queryParameters) {
-                path += insertedQueryParameters === 0 ?
+                if (typeof queryParameters[i] === 'undefined') {
+                    continue;
+                }
+                parsedQueryParameters += insertedQueryParameters === 0 ?
                     `?${i}=${queryParameters[i]}` :
                     `&${i}=${queryParameters[i]}`;
                 insertedQueryParameters++;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -60,4 +60,9 @@ export interface IAPIDriver {
     multiRemove(keys: string[], callback?: (errors?: Error[]) => void);
 }
 
-export type APIMiddleware = (serviceDefinition: IAPIService, fullPath: string, options?: IFetchOptions) => any;
+export interface IMiddlewarePaths {
+    fullPath: string;
+    withoutQueryParams: string;
+}
+
+export type APIMiddleware = (serviceDefinition: IAPIService, paths: IMiddlewarePaths, options?: IFetchOptions) => any;


### PR DESCRIPTION
## Breaking change

* Your endpoint's parsed path is now available without its query parameters in your middlewares' signature.

> The third argument supplied to the middleware is now an object with
both the fullPath as it used to be and your path without its query
parameters.
This can be useful in some cases, when generating authentication
headers, for instance.

## Features

* You can now pass an undefined value to both `queryParameters` and `pathParameters.`

> They will simply be ignored during the parsing of your paths. This is
is much easier than having to create an intermediate var with your
fetch options since you don’t have to care whether your variable is
defined or not.