### PR TITLE
v2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Key | Type | Description | Example
 `disableCache` | `boolean` | Optional, completely disables caching (overriden by service definitions & `fetch`'s `option` parameter)
 `cacheExpiration` | `number` | Optional default expiration of cached data in ms (overriden by service definitions & `fetch`'s `option` parameter)
 `cachePrefix` | `string` | Optional, prefix of the keys stored on your cache, defaults to `offlineApiCache`
+`ignoreHeadersWhenCaching` | `boolean` | Optional, your requests will be cached independently from the headers you sent. Defaults to `false`
 `capServices` | `boolean` | Optional, enable capping for every service, defaults to `false`, see [limiting the size of your cache](#limiting-the-size-of-your-cache)
 `capLimit` | `number` | Optional quantity of cached items for each service, defaults to `50`, see [limiting the size of your cache](#limiting-the-size-of-your-cache)
 `offlineDriver` | `IAPIDriver` | Optional, see [use your own driver for caching](#use-your-own-driver-for-caching)
@@ -180,6 +181,7 @@ Key | Type | Description | Example
 `disableCache` | `boolean` | Optional, disables the cache for this service (override your [API's global options](#api-options))
 `capService` | `boolean` | Optional, enable or disable capping for this specific service, see [limiting the size of your cache](#limiting-the-size-of-your-cache)
 `capLimit` | `number` | Optional quantity of cached items for this specific service, defaults to `50`, see [limiting the size of your cache](#limiting-the-size-of-your-cache)
+`ignoreHeadersWhenCaching` | `boolean` | Optional, your requests will be cached independently from the headers you sent. Defaults to `false`
 `rawData` | `boolean` | Disables JSON parsing from your network requests, useful if you want to fetch XML or anything else from your api
 
 ## Fetch options

--- a/demo/package.json
+++ b/demo/package.json
@@ -9,7 +9,7 @@
 	"dependencies": {
 		"react": "16.0.0-alpha.12",
 		"react-native": "0.47.1",
-		"react-native-offline-api": "2.0.0"
+		"react-native-offline-api": "2.1.0"
 	},
 	"devDependencies": {
 		"babel-jest": "20.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-offline-api",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Offline first API wrapper for react-native",
   "main": "./dist/index.js",
   "types": "./src/index.d.ts",

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -7,6 +7,7 @@ export interface IAPIOptions {
     disableCache?: boolean;
     cacheExpiration?: number;
     cachePrefix?: string;
+    ignoreHeadersWhenCaching?: boolean;
     capServices?: boolean;
     capLimit?: number;
     offlineDriver: IAPIDriver;
@@ -19,6 +20,7 @@ export interface IAPIService {
     domain?: string;
     prefix?: string;
     middlewares?: APIMiddleware[];
+    ignoreHeadersWhenCaching?: boolean;
     disableCache?: boolean;
     capService?: boolean;
     capLimit?: number;


### PR DESCRIPTION
## Features

* Add `ignoreHeadersWhenCaching` option. This is available at API, service and fetch options level. Enabling this will make sure you'll use your cached data when you're firing the same request but with different headers. This is useful if you need to sign all your API calls with the current date for example.